### PR TITLE
Add a main section in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "type": "MIT",
     "url": "https://github.com/nadangergeo/RWD-Table-Patterns/blob/master/LICENSE-MIT"
   },
+  "main": "dist/js/rwd-table",
   "devDependencies": {
     "grunt": "~0.4.4",
     "grunt-banner": "^0.2.3",


### PR DESCRIPTION
This PR allows to load the plugin using only the package name when using Webpack:

```javascript
// before
require('RWD-Table-Patterns/dist/js/rwd-table');

// after
require('RWD-Table-Patterns');
```