### PR TITLE
Optimize fixedNavbar height detection

### DIFF
--- a/src/js/rwd-table.js
+++ b/src/js/rwd-table.js
@@ -312,7 +312,7 @@
         //Is there a fixed navbar?
         if($(that.options.fixedNavbar).length) {
             var $navbar = $(that.options.fixedNavbar).first();
-            navbarHeight = $navbar.height();
+            navbarHeight = $navbar.outerHeight();
             scrollTop = scrollTop + navbarHeight;
         }
 


### PR DESCRIPTION
Like Bootstrap navbar, using jQuery `height()` could miss the outer height of the navbar, which this could use `outerHeight()` to exactly detect the navbar height instead for deviation.